### PR TITLE
added endpoint to support hot reload for intent manifest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ GA_UA_ID=''
 # BIGCOMMERCE settings
 BIGCOMMERCE_STORE_HASH=
 BIGCOMMERCE_TOKEN=
+
+# RELOAD INTENT MANIFEST
+# Add a webhook for the URL https://your-nextjs-app/api/publish/?secret=your-secret
+UNIFORM_WEBHOOK_SECRET=your-secret

--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ In order to create a new webhook:
    - Leave other settings as `Default`
    
 
-  Publish your Intents when done to make them avaible to your build.
+  Publish your Intents when done to make them available to your build.
 
 
+# Appendix C: Configuring hot reload for intent changes
+Any changes to intents requires an updated manifest be deployed to your app. The npm script `generate:intents` handles this. This script runs when the app starts. This script can also be configured to run when the intents are published using a Uniform Webhook.
+
+> NOTE: Since Uniform sends a request to your app, your app must be accessible via the internet. You can use ngrok to expose your app.
+
+1. Set the following env var value:
+   ```
+   UNIFORM_WEBHOOK_SECRET=your-secret
+   ```
+1. In Uniform, add a webhook that calls the `/api/publish` endpoint and passes the webhook secret value:
+   ```
+   https://yoursite.com/api/publish/?secret=your-secret
+   ```

--- a/pages/api/publish.ts
+++ b/pages/api/publish.ts
@@ -1,0 +1,26 @@
+import { NextApiHandler } from 'next';
+
+const handler: NextApiHandler = async (req, res) => {
+  const secret = req.query.secret;
+  if (!process.env.UNIFORM_WEBHOOK_SECRET || !secret) {
+    res.status(200).json({ status: 'OK' });
+    return;
+  }
+  if (process.env.UNIFORM_WEBHOOK_SECRET != secret) {
+    res.status(500).json({ status: 'Invalid secret.' });
+    return;
+  }
+  console.log("Publish command received.");
+  const exec = require('child_process').exec;
+  exec("npx uniform optimize manifest download --output ./lib/intentManifest.json", function(err, stdout, stderr) {
+    if (err) {
+      console.error(err);
+    }
+    else {
+      console.log(stdout);
+    }
+  });
+  res.status(200).json({ status: 'OK' })
+};
+
+export default handler;


### PR DESCRIPTION
This is to make demoing this solution easier. Since making any changes to intents requires the intent manifest be downloaded, you have to do this manually by running an npm script. This interferes with the demo flow. 

It is better if, when the changes are published, that the app:
1. be notified that changes were published
2. run the npm script